### PR TITLE
Fix segfault in Fortran example

### DIFF
--- a/f90/matrix.F90
+++ b/f90/matrix.F90
@@ -31,7 +31,7 @@ module matrix_mod
     type(matrix) :: a
     integer      :: n, num_rows, nnz, offsets(27), &
                     zstride, ystride, idx,         &
-                    i, j, x, y, z
+                    i, j, k, x, y, z
     real(8)      :: coefs(27)
     integer, pointer :: arow_offsets(:),acols(:)
     real(8), pointer :: acoefs(:)
@@ -69,9 +69,9 @@ module matrix_mod
     do i=1,num_rows
       arow_offsets(i) = idx
       do j=1,27
-        n=i+offsets(j)
-        if ((n.ge.1).and.(n.le.num_rows)) then
-          a%cols(idx) = n
+        k=i+offsets(j)
+        if ((k.ge.1).and.(k.le.num_rows)) then
+          a%cols(idx) = k
           a%coefs(idx) = coefs(j)
           idx = idx + 1
         endif

--- a/f90/original/matrix.F90
+++ b/f90/original/matrix.F90
@@ -31,7 +31,7 @@ module matrix_mod
     type(matrix) :: a
     integer      :: n, num_rows, nnz, offsets(27), &
                     zstride, ystride, idx,         &
-                    i, j, x, y, z
+                    i, j, k, x, y, z
     real(8)      :: coefs(27)
     integer, pointer :: arow_offsets(:),acols(:)
     real(8), pointer :: acoefs(:)
@@ -69,9 +69,9 @@ module matrix_mod
     do i=1,num_rows
       arow_offsets(i) = idx
       do j=1,27
-        n=i+offsets(j)
-        if ((n.ge.1).and.(n.le.num_rows)) then
-          a%cols(idx) = n
+        k=i+offsets(j)
+        if ((k.ge.1).and.(k.le.num_rows)) then
+          a%cols(idx) = k
           a%coefs(idx) = coefs(j)
           idx = idx + 1
         endif

--- a/f90/step1.kernels/matrix.F90
+++ b/f90/step1.kernels/matrix.F90
@@ -31,7 +31,7 @@ module matrix_mod
     type(matrix) :: a
     integer      :: n, num_rows, nnz, offsets(27), &
                     zstride, ystride, idx,         &
-                    i, j, x, y, z
+                    i, j, k, x, y, z
     real(8)      :: coefs(27)
     integer, pointer :: arow_offsets(:),acols(:)
     real(8), pointer :: acoefs(:)
@@ -69,9 +69,9 @@ module matrix_mod
     do i=1,num_rows
       arow_offsets(i) = idx
       do j=1,27
-        n=i+offsets(j)
-        if ((n.ge.1).and.(n.le.num_rows)) then
-          a%cols(idx) = n
+        k=i+offsets(j)
+        if ((k.ge.1).and.(k.le.num_rows)) then
+          a%cols(idx) = k
           a%coefs(idx) = coefs(j)
           idx = idx + 1
         endif

--- a/f90/step1.parallel/matrix.F90
+++ b/f90/step1.parallel/matrix.F90
@@ -31,7 +31,7 @@ module matrix_mod
     type(matrix) :: a
     integer      :: n, num_rows, nnz, offsets(27), &
                     zstride, ystride, idx,         &
-                    i, j, x, y, z
+                    i, j, k, x, y, z
     real(8)      :: coefs(27)
     integer, pointer :: arow_offsets(:),acols(:)
     real(8), pointer :: acoefs(:)
@@ -69,9 +69,9 @@ module matrix_mod
     do i=1,num_rows
       arow_offsets(i) = idx
       do j=1,27
-        n=i+offsets(j)
-        if ((n.ge.1).and.(n.le.num_rows)) then
-          a%cols(idx) = n
+        k=i+offsets(j)
+        if ((k.ge.1).and.(k.le.num_rows)) then
+          a%cols(idx) = k
           a%coefs(idx) = coefs(j)
           idx = idx + 1
         endif

--- a/f90/step2.kernels/matrix.F90
+++ b/f90/step2.kernels/matrix.F90
@@ -31,7 +31,7 @@ module matrix_mod
     type(matrix) :: a
     integer      :: n, num_rows, nnz, offsets(27), &
                     zstride, ystride, idx,         &
-                    i, j, x, y, z
+                    i, j, k, x, y, z
     real(8)      :: coefs(27)
     integer, pointer :: arow_offsets(:),acols(:)
     real(8), pointer :: acoefs(:)
@@ -69,9 +69,9 @@ module matrix_mod
     do i=1,num_rows
       arow_offsets(i) = idx
       do j=1,27
-        n=i+offsets(j)
-        if ((n.ge.1).and.(n.le.num_rows)) then
-          a%cols(idx) = n
+        k=i+offsets(j)
+        if ((k.ge.1).and.(k.le.num_rows)) then
+          a%cols(idx) = k
           a%coefs(idx) = coefs(j)
           idx = idx + 1
         endif

--- a/f90/step2.parallel/matrix.F90
+++ b/f90/step2.parallel/matrix.F90
@@ -31,7 +31,7 @@ module matrix_mod
     type(matrix) :: a
     integer      :: n, num_rows, nnz, offsets(27), &
                     zstride, ystride, idx,         &
-                    i, j, x, y, z
+                    i, j, k, x, y, z
     real(8)      :: coefs(27)
     integer, pointer :: arow_offsets(:),acols(:)
     real(8), pointer :: acoefs(:)
@@ -69,9 +69,9 @@ module matrix_mod
     do i=1,num_rows
       arow_offsets(i) = idx
       do j=1,27
-        n=i+offsets(j)
-        if ((n.ge.1).and.(n.le.num_rows)) then
-          a%cols(idx) = n
+        k=i+offsets(j)
+        if ((k.ge.1).and.(k.le.num_rows)) then
+          a%cols(idx) = k
           a%coefs(idx) = coefs(j)
           idx = idx + 1
         endif

--- a/f90/step3.kernels/matrix.F90
+++ b/f90/step3.kernels/matrix.F90
@@ -31,7 +31,7 @@ module matrix_mod
     type(matrix) :: a
     integer      :: n, num_rows, nnz, offsets(27), &
                     zstride, ystride, idx,         &
-                    i, j, x, y, z
+                    i, j, k, x, y, z
     real(8)      :: coefs(27)
     integer, pointer :: arow_offsets(:),acols(:)
     real(8), pointer :: acoefs(:)
@@ -69,9 +69,9 @@ module matrix_mod
     do i=1,num_rows
       arow_offsets(i) = idx
       do j=1,27
-        n=i+offsets(j)
-        if ((n.ge.1).and.(n.le.num_rows)) then
-          a%cols(idx) = n
+        k=i+offsets(j)
+        if ((k.ge.1).and.(k.le.num_rows)) then
+          a%cols(idx) = k
           a%coefs(idx) = coefs(j)
           idx = idx + 1
         endif

--- a/f90/step3.parallel/matrix.F90
+++ b/f90/step3.parallel/matrix.F90
@@ -31,7 +31,7 @@ module matrix_mod
     type(matrix) :: a
     integer      :: n, num_rows, nnz, offsets(27), &
                     zstride, ystride, idx,         &
-                    i, j, x, y, z
+                    i, j, k, x, y, z
     real(8)      :: coefs(27)
     integer, pointer :: arow_offsets(:),acols(:)
     real(8), pointer :: acoefs(:)
@@ -69,9 +69,9 @@ module matrix_mod
     do i=1,num_rows
       arow_offsets(i) = idx
       do j=1,27
-        n=i+offsets(j)
-        if ((n.ge.1).and.(n.le.num_rows)) then
-          a%cols(idx) = n
+        k=i+offsets(j)
+        if ((k.ge.1).and.(k.le.num_rows)) then
+          a%cols(idx) = k
           a%coefs(idx) = coefs(j)
           idx = idx + 1
         endif


### PR DESCRIPTION
The allocate_3d_poisson_matrix routine tried to reuse and overwrite its
'n' argument which was declared a parameter in the calling (main) routine.
Replaced 'n' with a local variable 'k'.